### PR TITLE
fix: 修复 Git diff 打开后面板收起

### DIFF
--- a/assets/js/app/CmDiff.test.tsx
+++ b/assets/js/app/CmDiff.test.tsx
@@ -1,0 +1,30 @@
+import * as Octane from "octane";
+import { render, screen } from "@octanejs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import CmDiff from "./CmDiff";
+
+describe("CmDiff hunk actions", () => {
+  it("mounts action buttons with their patch callbacks intact", async () => {
+    const onClick = vi.fn();
+
+    render(
+      <CmDiff
+        oldText={"old\n"}
+        newText={"new\n"}
+        mode="split"
+        wrap={true}
+        filename="sample.txt"
+        chunkActions={[{ label: "Stage hunk", kind: "primary", onClick }]}
+      />,
+    );
+
+    const button = await screen.findByRole("button", { name: "Stage hunk" });
+    button.click();
+    expect(onClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        forward: expect.stringContaining("@@"),
+        reverse: expect.stringContaining("@@"),
+      }),
+    );
+  });
+});

--- a/assets/js/app/CmDiff.tsx
+++ b/assets/js/app/CmDiff.tsx
@@ -132,11 +132,16 @@ const hunkButtonsField = StateField.define<DecorationSet>({
 });
 
 class HunkButtonsWidget extends WidgetType {
-  constructor(
-    readonly patch: ChunkPatch,
-    readonly actions: ChunkAction[],
-  ) {
+  readonly patch: ChunkPatch;
+  readonly actions: ChunkAction[];
+
+  constructor(patch: ChunkPatch, actions: ChunkAction[]) {
     super();
+    // Octane's current transform strips TypeScript parameter properties
+    // without emitting their assignments. Keep these explicit so production
+    // builds retain the hunk data used when CodeMirror mounts the widget.
+    this.patch = patch;
+    this.actions = actions;
   }
 
   override eq(other: HunkButtonsWidget) {


### PR DESCRIPTION
## 问题

点击 Git 面板中的已修改文件时，diff 会短暂出现，随后整个 Git 面板消失。生产构建中 Octane 转换器移除了 TypeScript 参数属性，但没有生成字段赋值，导致 CodeMirror 挂载 hunk 操作按钮时抛出 `this.actions is not iterable`。

## 修复

- 显式初始化 `HunkButtonsWidget` 的 patch 和 actions 字段
- 增加真实挂载 split diff 与 hunk 回调的回归测试

## 验证

- `mix precommit`
- 真实仓库连续打开 diff 5 次，Git 面板和 diff 均保持挂载，浏览器无错误