### PR TITLE
fix: preserve expanded file tree state

### DIFF
--- a/assets/js/app/App.tsx
+++ b/assets/js/app/App.tsx
@@ -26,6 +26,7 @@ import {
 } from "./shellTabs";
 import InputBar, { AGENT_LABELS } from "./InputBar";
 import FileDrawer from "./FileDrawer";
+import { createDirTreeCache } from "./fileDrawer/useDirTree";
 import type { Preview } from "./FilePreview";
 import { loadPreview } from "./loadPreview";
 import { focusOrphaned, isMac, Kbd, modShiftCombo, Tooltip } from "./shortcuts";
@@ -63,6 +64,7 @@ function terminalViewport() {
 }
 
 export default function App() {
+  const fileTreeCacheRef = useRef(createDirTreeCache());
   const { t } = useI18n();
   const [navOpen, setNavOpen] = useState(false);
   // Desktop sidebar collapse (VS Code's Ctrl/Cmd+B), remembered per browser.
@@ -1132,6 +1134,7 @@ export default function App() {
 
       {drawerOpen && active && (
         <FileDrawer
+          treeCache={fileTreeCacheRef.current}
           path={drawerPath ?? active.cwd}
           width={drawerW}
           onResize={(x) => setDrawerW(clampWidth(window.innerWidth - x, 260, 720))}

--- a/assets/js/app/FileDrawer.tsx
+++ b/assets/js/app/FileDrawer.tsx
@@ -13,7 +13,7 @@ import { buildTreeRows, crumbs, relativePath } from "./fileDrawer/tree";
 import type { DeleteTarget, SelectableRow, TreeRow } from "./fileDrawer/tree";
 import { RenameInput } from "./RenameInput";
 import { Chevron, DownloadIcon, Row, UploadIcon } from "./fileDrawer/rows";
-import { useDirTree } from "./fileDrawer/useDirTree";
+import { useDirTree, type DirTreeCache } from "./fileDrawer/useDirTree";
 import { useFileOps } from "./fileDrawer/useFileOps";
 import { useGitStatus } from "./hooks/useGitStatus";
 import { buildGitDecorations, gitDecorationForPath } from "./gitDecorations";
@@ -31,6 +31,8 @@ type Props = {
   onToggleFollow: () => void;
   onClose: () => void;
   onError: (message: string) => void;
+  /** App-lifetime snapshots keep folders open while this panel is temporarily unmounted. */
+  treeCache?: DirTreeCache;
   /** Desktop width in px (draggable via the left-edge handle). */
   width?: number;
   onResize?: (clientX: number) => void;
@@ -44,6 +46,7 @@ export default function FileDrawer({
   onToggleFollow,
   onClose,
   onError,
+  treeCache,
   width,
   onResize,
   onResetWidth,
@@ -55,7 +58,7 @@ export default function FileDrawer({
     refreshSoon: refreshGitStatusSoon,
   } = useGitStatus(path, onError, { watch: false });
   const { root, children, expanded, loadingDirs, refreshDir, refreshAll, toggleDir, expandDir } =
-    useDirTree(path, onError, refreshGitStatusSoon);
+    useDirTree(path, onError, { onExternalChange: refreshGitStatusSoon, cache: treeCache });
   const [showHidden, setShowHidden] = useState(false);
   const [preview, setPreview] = useState<Preview | null>(null);
   const [editOnOpen, setEditOnOpen] = useState(false);

--- a/assets/js/app/fileDrawer/useDirTree.test.tsx
+++ b/assets/js/app/fileDrawer/useDirTree.test.tsx
@@ -1,8 +1,8 @@
 import { act, renderHook, waitFor } from "@octanejs/testing-library";
 import * as Octane from "octane";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { I18nProvider } from "../i18n";
-import { useDirTree } from "./useDirTree";
+import { I18nProvider, useI18n } from "../i18n";
+import { createDirTreeCache, useDirTree } from "./useDirTree";
 
 const listDirectoryMock = vi.hoisted(() => vi.fn());
 vi.mock("../../ash_rpc", () => ({
@@ -58,7 +58,7 @@ describe("useDirTree — change-storm handling", () => {
   });
 
   it("a burst of changed frames for one expanded ancestor costs ONE refetch", async () => {
-    const { result } = renderHook(() => useDirTree("/proj", () => {}, undefined), { wrapper });
+    const { result } = renderHook(() => useDirTree("/proj", () => {}), { wrapper });
 
     // Initial root load.
     await waitFor(() => expect(result.current.root?.path).toBe("/proj"));
@@ -81,7 +81,7 @@ describe("useDirTree — change-storm handling", () => {
   });
 
   it("restores a root's expanded folders after the drawer path leaves and returns", async () => {
-    const { result, rerender } = renderHook(({ p }) => useDirTree(p, () => {}, undefined), {
+    const { result, rerender } = renderHook(({ p }) => useDirTree(p, () => {}), {
       wrapper,
       initialProps: { p: "/proj" },
     });
@@ -104,8 +104,39 @@ describe("useDirTree — change-storm handling", () => {
     expect(result.current.expanded.has("/proj/lib")).toBe(true);
   });
 
+  it("does not reload or restore the root for unrelated context changes", async () => {
+    const { result } = renderHook(
+      () => ({ tree: useDirTree("/proj", () => {}), i18n: useI18n() }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.tree.root?.path).toBe("/proj"));
+
+    const afterMount = listDirectoryMock.mock.calls.length;
+    act(() => {
+      result.current.i18n.setLocale("zh-CN");
+    });
+    await act(async () => await Promise.resolve());
+
+    expect(listDirectoryMock).toHaveBeenCalledTimes(afterMount);
+  });
+
+  it("restores expanded folders after the drawer hook unmounts and remounts", async () => {
+    const cache = createDirTreeCache();
+    const first = renderHook(() => useDirTree("/proj", () => {}, { cache }), { wrapper });
+    await waitFor(() => expect(first.result.current.root?.path).toBe("/proj"));
+    await act(async () => {
+      await first.result.current.toggleDir("/proj/lib");
+    });
+    expect(first.result.current.expanded.has("/proj/lib")).toBe(true);
+    first.unmount();
+
+    const second = renderHook(() => useDirTree("/proj", () => {}, { cache }), { wrapper });
+    await waitFor(() => expect(second.result.current.root?.path).toBe("/proj"));
+    expect(second.result.current.expanded.has("/proj/lib")).toBe(true);
+  });
+
   it("malformed frames are ignored and do not refetch", async () => {
-    const { result } = renderHook(() => useDirTree("/proj", () => {}, undefined), { wrapper });
+    const { result } = renderHook(() => useDirTree("/proj", () => {}), { wrapper });
     await waitFor(() => expect(result.current.root?.path).toBe("/proj"));
     const afterMount = listDirectoryMock.mock.calls.length;
 

--- a/assets/js/app/fileDrawer/useDirTree.ts
+++ b/assets/js/app/fileDrawer/useDirTree.ts
@@ -11,6 +11,23 @@ import type { Entry, Listing } from "./tree";
 // selection type has no shape for arrays of typed maps, hence the cast.
 const DIR_FIELDS = ["path", "parent", "entries"] as unknown as ListDirectoryFields;
 
+type DirTreeSnapshot = {
+  root: Listing;
+  children: Record<string, Entry[]>;
+  expanded: Set<string>;
+};
+
+export type DirTreeCache = Map<string, DirTreeSnapshot>;
+
+export function createDirTreeCache(): DirTreeCache {
+  return new Map();
+}
+
+type Options = {
+  onExternalChange?: () => void;
+  cache?: DirTreeCache;
+};
+
 /**
  * The directory tree's data layer: the root listing, loaded children,
  * expansion state, and the /files/watch socket keeping everything fresh
@@ -19,7 +36,7 @@ const DIR_FIELDS = ["path", "parent", "entries"] as unknown as ListDirectoryFiel
 export function useDirTree(
   path: string,
   onError: (message: string) => void,
-  onExternalChange?: () => void,
+  { onExternalChange, cache: sharedCache }: Options = {},
 ) {
   const { t } = useI18n();
   // Held in a ref so an inline callback from the caller cannot change
@@ -27,20 +44,17 @@ export function useDirTree(
   // render (an unbounded refetch loop).
   const errorRef = useRef(onError);
   errorRef.current = onError;
+  const translateRef = useRef(t);
+  translateRef.current = t;
   const [root, setRoot] = useState<Listing | null>(null);
   const [children, setChildren] = useState<Record<string, Entry[]>>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set());
 
-  // Remember each root's tree (expanded folders + loaded children) so switching
-  // the drawer path away and back — chiefly switching session tabs, which
-  // retargets the drawer at the new session's cwd — restores it instead of
-  // collapsing everything to the root. Kept in a ref (survives the path-change
-  // re-renders) on the single app-level FileDrawer; lost only when the drawer
-  // itself unmounts.
-  const cacheRef = useRef<
-    Map<string, { root: Listing; children: Record<string, Entry[]>; expanded: Set<string> }>
-  >(new Map());
+  // Keep a hook-local cache for standalone consumers and tests. The app passes
+  // a longer-lived cache so a temporarily unmounted drawer can restore its tree.
+  const [localCache] = useState(createDirTreeCache());
+  const cache = sharedCache ?? localCache;
 
   const fetchDir = useCallback(
     async (target: string): Promise<Listing | null> => {
@@ -49,10 +63,10 @@ export function useDirTree(
         fields: DIR_FIELDS,
       });
       if (result.ok) return result.data;
-      errorRef.current(result.error || t("couldNotListDirectory"));
+      errorRef.current(result.error || translateRef.current("couldNotListDirectory"));
       return null;
     },
-    [t],
+    [],
   );
 
   const refreshDir = useCallback(
@@ -65,8 +79,8 @@ export function useDirTree(
 
   // Keep each root's snapshot current so it can be restored later.
   useEffect(() => {
-    if (root) cacheRef.current.set(root.path, { root, children, expanded });
-  }, [root, children, expanded]);
+    if (root) cache.set(root.path, { root, children, expanded });
+  }, [cache, root, children, expanded]);
 
   // (Re)load the tree root whenever the drawer path changes. If we've shown
   // this root before, restore its snapshot instantly (expanded folders intact)
@@ -74,7 +88,7 @@ export function useDirTree(
   // doesn't re-collapse the tree; otherwise load it fresh.
   useEffect(() => {
     let stale = false;
-    const cached = cacheRef.current.get(path);
+    const cached = cache.get(path);
 
     if (cached) {
       setRoot(cached.root);
@@ -103,7 +117,7 @@ export function useDirTree(
     return () => {
       stale = true;
     };
-  }, [path, fetchDir]);
+  }, [cache, path, fetchDir]);
 
   // External changes (terminal commands, agents deleting/creating files)
   // don't announce themselves — a watch socket does: the server watches the

--- a/e2e/files.spec.js
+++ b/e2e/files.spec.js
@@ -66,6 +66,19 @@ test.describe("Given 打开文件抽屉的用户", () => {
       // 切回 A：nested 无需再点就仍是展开的。
       await h.selectSession(page, a);
       await expect(page.locator(inner)).toBeVisible();
+
+      // 文件抽屉切到 Git 等工具时会卸载；重新打开后仍应恢复展开状态。
+      await page.click("#toggle-git-button");
+      await expect(page.locator("#file-tree")).toHaveCount(0);
+      await page.click("#toggle-drawer-button");
+      await expect(page.locator(inner)).toBeVisible();
+
+      // 打开并关闭内层文件预览也不能触发整棵树重新加载或折叠。
+      await page.click(inner);
+      await expect(page.locator("#file-preview")).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(page.locator("#file-preview")).toHaveCount(0);
+      await expect(page.locator(inner)).toBeVisible();
     } finally {
       // Clean up both sessions so a later spec never inherits a session whose
       // cwd we're about to delete, then remove B's scratch dir.


### PR DESCRIPTION
修复文件树在部分文件打开、面板切换和无关上下文更新后自动折叠的问题。

- 将展开目录快照提升到 App 生命周期
- 避免 i18n 更新触发根目录重新加载
- 补充 hook 卸载重挂和真实浏览器回归

验证：`mix precommit`；Playwright 定向回归。