### PR TITLE
chore(release): prepare v0.27.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Dala.MixProject do
   def project do
     [
       app: :dala,
-      version: "0.27.2",
+      version: "0.27.4",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Bump the application version from `0.27.2` to `0.27.4`.
- Prepare the merged Windows native server and one-command installer work for the next server release.

## Release rationale

The public `v0.27.3` release predates the current `upstream/main` lineage and does not contain Windows server assets. `v0.27.4` is the next unused stable tag and will be built from the current main branch, which includes PR #8.

The release workflow validates that the runtime version matches the pushed tag, so the Mix project version must be updated before tagging.

## Release procedure after merge

1. Push an annotated `v0.27.4` tag at the merged main commit.
2. Let `.github/workflows/release.yml` build Linux, macOS and Windows artifacts.
3. Verify the generated Release contains each archive and matching SHA-256 checksum, including `dala-v0.27.4-windows-x86_64.zip`.

## Validation

- `git diff --check` passes.
- The change is limited to the version field in `mix.exs`.
- `mix format --check-formatted mix.exs` could not run locally because the environment has not downloaded the project's `ecto_sql` dependency; CI remains the authoritative full validation.
